### PR TITLE
feat(plants): add variety field to garden plants

### DIFF
--- a/square-gardener/src/components/PlantCard.jsx
+++ b/square-gardener/src/components/PlantCard.jsx
@@ -35,7 +35,12 @@ function PlantCard({ plant, gardenPlant, onAdd, onRemove, showAddButton = false 
     <div className="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow">
       <div className="flex justify-between items-start mb-3">
         <div>
-          <h3 className="text-lg font-semibold text-primary">{plant.name}</h3>
+          <h3 className="text-lg font-semibold text-primary">
+            {plant.name}
+            {gardenPlant?.variety && (
+              <span className="text-gray-600 font-normal"> - {gardenPlant.variety}</span>
+            )}
+          </h3>
           <p className="text-sm text-gray-500 italic">{plant.scientificName}</p>
         </div>
         <div className="text-2xl">{getSunIcon(plant.sunRequirement)}</div>
@@ -130,7 +135,8 @@ PlantCard.propTypes = {
     plantId: PropTypes.string.isRequired,
     plantedDate: PropTypes.string.isRequired,
     lastWatered: PropTypes.string.isRequired,
-    notes: PropTypes.string
+    notes: PropTypes.string,
+    variety: PropTypes.string
   }),
   onAdd: PropTypes.func,
   onRemove: PropTypes.func,

--- a/square-gardener/src/components/PlantCard.test.jsx
+++ b/square-gardener/src/components/PlantCard.test.jsx
@@ -132,6 +132,30 @@ describe('PlantCard', () => {
     });
   });
 
+  describe('variety display', () => {
+    it('shows variety when gardenPlant has variety', () => {
+      const gardenPlantWithVariety = { ...mockGardenPlant, variety: 'Cherokee Purple' };
+      render(<PlantCard plant={mockPlant} gardenPlant={gardenPlantWithVariety} />);
+      expect(screen.getByText('- Cherokee Purple')).toBeInTheDocument();
+    });
+
+    it('does not show variety when gardenPlant.variety is null', () => {
+      const gardenPlantWithNullVariety = { ...mockGardenPlant, variety: null };
+      render(<PlantCard plant={mockPlant} gardenPlant={gardenPlantWithNullVariety} />);
+      expect(screen.queryByText(/-/)).not.toBeInTheDocument();
+    });
+
+    it('does not show variety when gardenPlant.variety is undefined', () => {
+      render(<PlantCard plant={mockPlant} gardenPlant={mockGardenPlant} />);
+      expect(screen.queryByText(/- /)).not.toBeInTheDocument();
+    });
+
+    it('does not show variety without gardenPlant', () => {
+      render(<PlantCard plant={mockPlant} />);
+      expect(screen.queryByText(/- /)).not.toBeInTheDocument();
+    });
+  });
+
   describe('add button', () => {
     it('shows add button when showAddButton is true', () => {
       const onAdd = vi.fn();

--- a/square-gardener/src/utils/storage.js
+++ b/square-gardener/src/utils/storage.js
@@ -42,14 +42,16 @@ export const saveGardenPlants = (plants) => {
  * @param {string} bedId - ID of the bed to assign the plant to
  * @param {number} quantity - Number of plants (default: 1)
  * @param {string} plantedDate - ISO 8601 date string (default: now)
+ * @param {string|null} variety - Plant variety/cultivar name (default: null)
  */
-export const addGardenPlant = (plantId, bedId, quantity = 1, plantedDate = new Date().toISOString()) => {
+export const addGardenPlant = (plantId, bedId, quantity = 1, plantedDate = new Date().toISOString(), variety = null) => {
   const plants = getGardenPlants();
   const newPlant = {
     id: `garden-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
     plantId,
     bedId,
     quantity,
+    variety,
     plantedDate,
     lastWatered: plantedDate,
     notes: ''

--- a/square-gardener/src/utils/storage.test.js
+++ b/square-gardener/src/utils/storage.test.js
@@ -109,6 +109,22 @@ describe('storage utilities', () => {
       addGardenPlant('carrot', 'bed-2');
       expect(getGardenPlants()).toHaveLength(3);
     });
+
+    it('adds a new plant with null variety by default', () => {
+      const result = addGardenPlant('tomato', 'bed-1');
+      expect(result.variety).toBeNull();
+    });
+
+    it('adds a new plant with custom variety', () => {
+      const result = addGardenPlant('tomato', 'bed-1', 1, new Date().toISOString(), 'Cherokee Purple');
+      expect(result.variety).toBe('Cherokee Purple');
+    });
+
+    it('persists variety field in storage', () => {
+      addGardenPlant('tomato', 'bed-1', 1, new Date().toISOString(), 'Brandywine');
+      const plants = getGardenPlants();
+      expect(plants[0].variety).toBe('Brandywine');
+    });
   });
 
   describe('removeGardenPlant', () => {


### PR DESCRIPTION
Allow tracking of plant cultivars (e.g., "Cherokee Purple" tomato). The variety field is optional and displays after the plant name in PlantCard when provided.

**Related to**: Closes #8

**Changes**:
- Added `variety` parameter to `addGardenPlant()` in storage.js
- Updated PlantCard.jsx to display variety after plant name
- Added comprehensive tests for both storage and PlantCard changes
- All tests pass with 100% coverage