### PR TITLE
feat: Add GitHub Pages SPA routing support

### DIFF
--- a/square-gardener/index.html
+++ b/square-gardener/index.html
@@ -5,6 +5,28 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Square Gardener</title>
+    <script>
+      // GitHub Pages SPA redirect handler
+      // Decode the route from the query string and restore it via History API
+      (function() {
+        var redirect = sessionStorage.redirect;
+        delete sessionStorage.redirect;
+        if (redirect && redirect !== location.href) {
+          history.replaceState(null, null, redirect);
+        }
+      })();
+
+      // Store the redirect target before the React app loads
+      (function() {
+        var l = window.location;
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s) {
+            return s.replace(/~and~/g, '&');
+          }).join('?');
+          sessionStorage.redirect = l.pathname.slice(0, -1) + decoded + l.hash;
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/square-gardener/public/404.html
+++ b/square-gardener/public/404.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Square Gardener</title>
+    <script>
+      // GitHub Pages SPA fallback
+      // Capture the current path and redirect to index.html with encoded route info
+      (function() {
+        var pathSegmentsToKeep = 1; // Keep '/Square-Gardener/' segment
+
+        var l = window.location;
+        var redirect = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+          l.pathname.split('/').slice(0, pathSegmentsToKeep + 1).join('/') + '/?/' +
+          l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash;
+
+        l.replace(redirect);
+      })();
+    </script>
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>

--- a/square-gardener/src/App.jsx
+++ b/square-gardener/src/App.jsx
@@ -8,7 +8,7 @@ import Calendar from './pages/Calendar';
 
 function App() {
   return (
-    <Router>
+    <Router basename="/Square-Gardener/">
       <div className="min-h-screen flex flex-col">
         <header className="bg-gradient-to-br from-primary to-primary-light text-white py-6 px-4 sm:py-8 text-center shadow-md">
           <h1 className="m-0 text-2xl sm:text-3xl md:text-4xl font-bold">

--- a/square-gardener/src/App.test.jsx
+++ b/square-gardener/src/App.test.jsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import App from './App';
 
 describe('App', () => {
+  beforeEach(() => {
+    // Reset window location for each test
+    window.history.pushState({}, '', '/Square-Gardener/');
+  });
+
   it('renders the Square Gardener header', () => {
     render(<App />);
     const headers = screen.getAllByText(/Square Gardener/);


### PR DESCRIPTION
## Summary
This PR implements the following tickets:

- **#49**: Add 404.html SPA fallback for direct URL access on GitHub Pages
- **#50**: Fix BrowserRouter missing basename for GitHub Pages deployment

## Changes

### #50: BrowserRouter basename
- Added `basename="/Square-Gardener/"` to BrowserRouter in `App.jsx`
- Updated tests to set window location to `/Square-Gardener/` before each test

### #49: 404.html SPA fallback
- Created `public/404.html` that captures path/query/hash and redirects to app root
- Updated `index.html` to decode route info and restore via History API
- Uses `~and~` delimiter to safely encode `&` characters in query strings

## How It Works

1. User navigates directly to `/Square-Gardener/my-garden`
2. GitHub Pages serves `404.html` (no physical file exists)
3. `404.html` captures path and redirects to `/?/my-garden`
4. `index.html` decodes the route and uses `history.replaceState()` to restore the original URL
5. React Router takes over with the correct route

## Testing
- All tests passing (1121 tests)
- Coverage: 100%
- Lint: Clean

Closes #49
Closes #50

---
Generated with /multi-ticket-sprint