### PR TITLE
chore: standardize workflow notification body format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "repository": "${{ github.repository }}",
-              "workflow": "${{ github.workflow }}",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "action": "ci.success"
             }'
 
       - name: Notify CI Failure
@@ -79,6 +78,5 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "repository": "${{ github.repository }}",
-              "workflow": "${{ github.workflow }}",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "action": "ci.failure"
             }'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,10 +18,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "repository": "${{ github.repository }}",
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "pr_title": "${{ github.event.pull_request.title }}",
-              "pr_url": "${{ github.event.pull_request.html_url }}",
-              "author": "${{ github.event.pull_request.user.login }}"
+              "action": "pr.opened"
             }'
 
   test-and-coverage:
@@ -92,8 +89,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "repository": "${{ github.repository }}",
-              "workflow": "${{ github.workflow }}",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "action": "ci.success"
             }'
 
       - name: Notify CI Failure
@@ -105,6 +101,5 @@ jobs:
             -H "Content-Type: application/json" \
             -d '{
               "repository": "${{ github.repository }}",
-              "workflow": "${{ github.workflow }}",
-              "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "action": "ci.failure"
             }'


### PR DESCRIPTION
## Summary
- Updated notification curl bodies to use consistent format with only `repository` and `action` fields
- Removed `workflow`, `run_url`, `pr_number`, `pr_title`, `pr_url`, and `author` fields

## Changes
- `.github/workflows/deploy.yml` - Updated ci.success and ci.failure notifications
- `.github/workflows/pr-checks.yml` - Updated pr.opened, ci.success, and ci.failure notifications

Generated with [Claude Code](https://claude.ai/code)